### PR TITLE
fix: module type issue in rollup & typescript config

### DIFF
--- a/packages/rollup-config/index.js
+++ b/packages/rollup-config/index.js
@@ -36,7 +36,8 @@ module.exports = ['es', 'cjs'].map(format => ({
             declaration: true,
             outDir: `dist/${format}`,
             exclude: ['**/*.test.ts'],
-            include: ['src/**/*', 'module.d.ts']
+            include: ['src/**/*', 'module.d.ts'],
+            module: format === 'es' ? 'esnext' : 'CommonJS'
         }),
         terser()
     ],

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -6,7 +6,7 @@
         "isolatedModules": true,
         "jsx": "react",
         "lib": ["es2017", "es2015", "dom", "es2018.promise"],
-        "module": "esnext",
+        "module": "CommonJS",
         "moduleResolution": "node",
         "noEmit": true,
         "resolveJsonModule": true,


### PR DESCRIPTION
affects: @medly/rollup-config, @medly/typescript-config

Add `CommonJS` as module in `tsypescript-config` and add proper module in `rollup-config` based on output module type.

### PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)

### What is the new behavior?

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
