### PR TITLE
fix: module type issue in rollup config

### DIFF
--- a/packages/rollup-config/index.js
+++ b/packages/rollup-config/index.js
@@ -37,7 +37,7 @@ module.exports = ['es', 'cjs'].map(format => ({
             outDir: `dist/${format}`,
             exclude: ['**/*.test.ts'],
             include: ['src/**/*', 'module.d.ts'],
-            module: format === 'es' ? 'esnext' : 'CommonJS'
+            module: 'esnext'
         }),
         terser()
     ],


### PR DESCRIPTION
affects: @medly/rollup-config

Add `esnext` as module in 'rollup-config'

### PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

### What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Fixes # (issue)

### What is the new behavior?

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
