### PR TITLE
feat: access rollup config from package json file

### DIFF
--- a/packages/rollup-config/README.md
+++ b/packages/rollup-config/README.md
@@ -10,10 +10,36 @@ yarn add -D @medly/rollup-config
 
 ## Usage
 
-Add below code in your `rollup.config.js`
+### 1. Use default settings
+
+Add below code in your `package.json`
+
+```json
+{
+ "script": {
+  "dist": "rollup --config node_modules/@medly/rollup-config/index.js"
+ }
+}
+```
+
+### 2. Overwrite default settings
+
+Add `rollup.config.js` file at root level with below code
 
 ```js
-import config from '@medly/rollup-config';
+const { configure } = require('@medly/rollup-config');
 
-export default config;
+module.exports = configure({
+ input = ["./src/index.ts"]
+});
+```
+
+Add below code in your `package.json`
+
+```json
+{
+ "script": {
+  "dist": "rollup --config rollup.config.js"
+ }
+}
 ```

--- a/packages/rollup-config/index.js
+++ b/packages/rollup-config/index.js
@@ -6,14 +6,14 @@ const path = require('path');
 const { terser } = require('rollup-plugin-terser');
 
 const PACKAGE_ROOT_PATH = process.cwd(),
-    SRC = path.join(PACKAGE_ROOT_PATH, 'src'),
-    INPUT = path.join(PACKAGE_ROOT_PATH, 'src/index.ts'),
+    SRC = path.join(PACKAGE_ROOT_PATH, './src'),
+    INPUT = path.join(PACKAGE_ROOT_PATH, './src/index.ts'),
     TS_CONFIG = path.join(PACKAGE_ROOT_PATH, './tsconfig.json'),
-    PKG_JSON = require(path.join(PACKAGE_ROOT_PATH, 'package.json'));
+    PKG_JSON = require(path.join(PACKAGE_ROOT_PATH, './package.json'));
 
 const extensions = ['.ts', '.tsx', '.js'];
 
-module.exports = ['es', 'cjs'].map(format => ({
+const configs = ['es', 'cjs'].map(format => ({
     input: INPUT,
     preserveModules: true,
     external: [...Object.keys(PKG_JSON.peerDependencies || {}), ...Object.keys(PKG_JSON.dependencies || {})],
@@ -47,3 +47,8 @@ module.exports = ['es', 'cjs'].map(format => ({
         dir: `dist/${format}`
     }
 }));
+
+const configure = (config = {}) => configs.map(cf => ({ ...cf, ...config }));
+
+module.exports = configs;
+module.exports.configure = configure;


### PR DESCRIPTION
affects: @medly/rollup-config

### PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

### What is the current behavior?

Currently we have to create separate rollup config to import medy config.

## Fixes # (issue)

### What is the new behavior?

Now we can directly access the config in`package.json` and also import the `configure` method to override the config.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
