### PR TITLE
fix: ignore index.html from copyWebpackPlugin

### DIFF
--- a/packages/webpack-config/configs/webpack.common.js
+++ b/packages/webpack-config/configs/webpack.common.js
@@ -71,7 +71,15 @@ module.exports = {
             }
         }),
         new CopyPlugin({
-            patterns: [{ from: PUBLIC, to: DIST }]
+            patterns: [
+                {
+                    from: PUBLIC,
+                    to: DIST,
+                    globOptions: {
+                        ignore: ['**/index.html']
+                    }
+                }
+            ]
         }),
         new ForkTsCheckerWebpackPlugin(),
         new CircularDependencyPlugin({


### PR DESCRIPTION
affects: @medly/webpack-config

### PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

### What is the current behavior?

Both `copy-webpack-plugin` & `html-webpack-plugin` are trying to modifying the same file.

## Fixes # (issue)

### What is the new behavior?

Ignore `index.html` file from `copy-webpack-plugin`.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

### Additional context

Add any other context or screenshots about the feature pr here.
