### PR TITLE
feat: support building javascript project also in rollup config

### DIFF
--- a/packages/rollup-config/README.md
+++ b/packages/rollup-config/README.md
@@ -51,3 +51,5 @@ Add below code in your `package.json`
  }
 }
 ```
+
+> **Note**: Add `tsconfig.json` file at the root level to emit type declaration files.

--- a/packages/rollup-config/index.js
+++ b/packages/rollup-config/index.js
@@ -3,52 +3,73 @@ const commonjs = require('@rollup/plugin-commonjs');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const typescript = require('@rollup/plugin-typescript');
 const path = require('path');
+const fs = require('fs');
 const { terser } = require('rollup-plugin-terser');
 
 const PACKAGE_ROOT_PATH = process.cwd(),
     SRC = path.join(PACKAGE_ROOT_PATH, './src'),
-    INPUT = path.join(PACKAGE_ROOT_PATH, './src/index.ts'),
-    TS_CONFIG = path.join(PACKAGE_ROOT_PATH, './tsconfig.json'),
     PKG_JSON = require(path.join(PACKAGE_ROOT_PATH, './package.json'));
 
-const extensions = ['.ts', '.tsx', '.js'];
+const extensions = ['.ts', '.tsx', '.js', '.jsx'];
 
-const configs = ['es', 'cjs'].map(format => ({
-    input: INPUT,
-    preserveModules: true,
-    external: [...Object.keys(PKG_JSON.peerDependencies || {}), ...Object.keys(PKG_JSON.dependencies || {})],
-    plugins: [
-        commonjs(),
-        nodeResolve({
-            extensions,
-            customResolveOptions: { preserveSymlinks: false },
-            mainFields: ['module', 'main']
-        }),
-        babel({
-            ...PKG_JSON.babel,
-            extensions,
-            babelHelpers: 'bundled'
-        }),
-        typescript({
-            tsconfig: TS_CONFIG,
-            rootDir: SRC,
-            baseUrl: PACKAGE_ROOT_PATH,
-            declaration: true,
-            outDir: `dist/${format}`,
-            exclude: ['**/*.test.ts'],
-            include: ['src/**/*', 'module.d.ts'],
-            module: 'esnext'
-        }),
-        terser()
-    ],
-    output: {
-        format,
-        exports: 'auto',
-        dir: `dist/${format}`
-    }
-}));
+const configs = ['es', 'cjs'].map(format => {
+    const TS_CONFIG = path.join(PACKAGE_ROOT_PATH, './tsconfig.json'),
+        isTypescriptProject = fs.existsSync(TS_CONFIG);
 
-const configure = (config = {}) => configs.map(cf => ({ ...cf, ...config }));
+    return {
+        input: path.join(PACKAGE_ROOT_PATH, `./src/index.${isTypescriptProject ? 'ts' : 'js'}`),
+        preserveModules: true,
+        external: [...Object.keys(PKG_JSON.peerDependencies || {}), ...Object.keys(PKG_JSON.dependencies || {})],
+        plugins: [
+            commonjs(),
+            nodeResolve({
+                extensions,
+                customResolveOptions: { preserveSymlinks: false },
+                mainFields: ['module', 'main']
+            }),
+            babel({
+                ...PKG_JSON.babel,
+                extensions,
+                babelHelpers: 'bundled'
+            }),
+            terser(),
+            ...(isTypescriptProject
+                ? [
+                      typescript({
+                          tsconfig: TS_CONFIG,
+                          rootDir: SRC,
+                          baseUrl: PACKAGE_ROOT_PATH,
+                          declaration: true,
+                          outDir: `dist/${format}`,
+                          exclude: ['**/*.test.ts'],
+                          include: ['src/**/*', 'module.d.ts'],
+                          module: 'esnext'
+                      })
+                  ]
+                : [])
+        ],
+        output: {
+            format,
+            exports: 'auto',
+            dir: `dist/${format}`
+        }
+    };
+});
+
+const merge = (target, source) =>
+    Object.entries(source).reduce(
+        (acc, [key, value]) => ({
+            ...acc,
+            ...(Array.isArray(value)
+                ? { [key]: Array.from(new Set(acc[key].concat(value))) }
+                : typeof value === 'object'
+                ? { [key]: merge(acc[key], value) }
+                : { [key]: value })
+        }),
+        { ...target }
+    );
+
+const configure = (config = {}) => configs.map(cf => merge(cf, config));
 
 module.exports = configs;
 module.exports.configure = configure;


### PR DESCRIPTION
affects: @medly/rollup-config

# PR Checklist

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Right now `rollup-config` is only supporting typescript project.

## What is the new behavior?

`rollup-config` will emit types if `tsconfig.json` file is added at the root level in the project.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

