### PR TITLE
feat: add strict null check in typescript config

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -11,8 +11,6 @@
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "strict": true,
-        "strictFunctionTypes": false,
-        "strictNullChecks": false,
         "target": "esnext",
         "types": ["jest", "node"]
     }


### PR DESCRIPTION
affects: @medly/typescript-config-react, @medly/typescript-config

BREAKING CHANGE:
This will catch all the strict null check error and hence might break existing code

# PR Checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Performance improves
- [ ] Adding missing tests
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Actually `strictNullCheck` is false right now and due to which issue like below can't be caught.

```tsx
type Props = {
   arr?: string[]
}

const Component: React.FC<Props> = ({ arr }) => <p>{arr.length}</p>
``` 
In above code `arr.length` will fail because `arr` prop is optional.

## What is the new behavior?

Eslint will catch all such kind of issues.

## Fixes #<issue_number>

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This will catch all the strict null check error and hence might break existing code.